### PR TITLE
Image type selection, minor code improvements

### DIFF
--- a/config/const_unix.go
+++ b/config/const_unix.go
@@ -1,5 +1,0 @@
-//go:build !windows
-
-package config
-
-const PATH_SEPARATOR = "/"

--- a/config/const_windows.go
+++ b/config/const_windows.go
@@ -1,5 +1,0 @@
-//go:build windows
-
-package config
-
-const PATH_SEPARATOR = "\\"

--- a/config/utils.go
+++ b/config/utils.go
@@ -17,6 +17,16 @@ type Config struct {
 
 var Cnf *Config
 var ProcessPath string
+var ImageTypes []string = []string{"grids", "heroes", "logos", "icons"}
+
+func IsValidImageType(imageType string) bool {
+	for _, v := range ImageTypes {
+		if v == imageType {
+			return true
+		}
+	}
+	return false
+}
 
 func init() {
 	viper.AddConfigPath("config/")
@@ -44,9 +54,7 @@ func init() {
 
 	path := "cache"
 
-	var imageTypes []string = []string{"grids", "heroes", "logos", "icons"}
-
-	for _, imageType := range imageTypes {
+	for _, imageType := range ImageTypes {
 		if _, err := os.Stat(filepath.Join(ProcessPath, path, imageType)); errors.Is(err, os.ErrNotExist) {
 			err := os.Mkdir(filepath.Join(ProcessPath, path, imageType), os.ModePerm)
 			if err != nil {

--- a/config/utils.go
+++ b/config/utils.go
@@ -44,10 +44,14 @@ func init() {
 
 	path := "cache"
 
-	if _, err := os.Stat(ProcessPath + PATH_SEPARATOR + path); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(ProcessPath+PATH_SEPARATOR+path, os.ModePerm)
-		if err != nil {
-			log.Println(err)
+	var imageTypes []string = []string{"grids", "heroes", "logos", "icons"}
+
+	for _, imageType := range imageTypes {
+		if _, err := os.Stat(filepath.Join(ProcessPath, path, imageType)); errors.Is(err, os.ErrNotExist) {
+			err := os.Mkdir(filepath.Join(ProcessPath, path, imageType), os.ModePerm)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 	}
 

--- a/controller/grid.go
+++ b/controller/grid.go
@@ -26,7 +26,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		searchType = "grids"
 	}
 
-	if (searchType != "grids") && (searchType != "heroes") && (searchType != "logos") && (searchType != "icons") {
+	if !config.IsValidImageType(searchType) {
 		w.WriteHeader(400)
 		w.Write([]byte("Invalid search type"))
 		return

--- a/controller/grid.go
+++ b/controller/grid.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/gorilla/mux"
 	"usebottles.com/steamgrid-proxy/config"
@@ -13,6 +14,7 @@ import (
 func Search(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	searchTerm := vars["gameName"]
+	searchType := vars["type"]
 
 	if searchTerm == "" {
 		w.WriteHeader(400)
@@ -20,7 +22,17 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	link := getFromCache(searchTerm)
+	if searchType == "" {
+		searchType = "grids"
+	}
+
+	if (searchType != "grids") && (searchType != "heroes") && (searchType != "logos") && (searchType != "icons") {
+		w.WriteHeader(400)
+		w.Write([]byte("Invalid search type"))
+		return
+	}
+
+	link := getFromCache(searchTerm, searchType)
 	if link != "" {
 		jsonRes, _ := json.Marshal(link)
 		w.WriteHeader(200)
@@ -28,7 +40,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := proxy.Search(searchTerm)
+	res, err := proxy.Search(searchTerm, searchType)
 
 	if err != nil {
 		if res == "404" {
@@ -45,8 +57,8 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonRes)
 }
 
-func getFromCache(g string) string {
-	data, err := os.ReadFile(config.ProcessPath + config.PATH_SEPARATOR + "cache" + config.PATH_SEPARATOR + g + ".txt")
+func getFromCache(g string, s string) string {
+	data, err := os.ReadFile(filepath.Join(config.ProcessPath, "cache", s, g+".txt"))
 	if err != nil {
 		return ""
 	}

--- a/main.go
+++ b/main.go
@@ -15,10 +15,11 @@ func main() {
 
 	apiRouter := router.PathPrefix("/api").Subrouter()
 	apiRouter.HandleFunc("/search/{gameName}", controller.Search).Methods("GET")
+	apiRouter.HandleFunc("/search/{gameName}/{type}", controller.Search).Methods("GET")
 
 	headersOk := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"})
 	originsOk := handlers.AllowedOrigins([]string{"*"})
 	methodsOk := handlers.AllowedMethods([]string{"GET", "HEAD", "OPTIONS"})
 
-	http.ListenAndServe(":" + cnf.Port, handlers.CORS(originsOk, headersOk, methodsOk)(router))
+	http.ListenAndServe(":"+cnf.Port, handlers.CORS(originsOk, headersOk, methodsOk)(router))
 }


### PR DESCRIPTION
Now it's possible to use `/api/search/Game Name/type` route where type can be `heroes`, `grids`, `logos`, `icons` (for other strings server will respond with 400 Bad Request)

For backwards compatibility I kept `/api/search/Game Name` route which will just default to `grids` type

This PR changes paths on the cache so to migrate existing caches it's required to move txt files from `cache/` to `cache/grids`

I also removed `const_unix.go` and `const_windows.go` files which were just exporting PATH_SEPARATOR. I completely removed need for that variable using `path/filepath` std lib - `filepath.Join()` method

